### PR TITLE
fixed AudioRecorder compatability bug

### DIFF
--- a/src/info/guardianproject/iocipher/camera/VideoCameraActivity.java
+++ b/src/info/guardianproject/iocipher/camera/VideoCameraActivity.java
@@ -511,7 +511,7 @@ public class VideoCameraActivity extends CameraBaseActivity {
 						e.printStackTrace();
 					}
 				 }
-				 else
+				 else if (audioRecord.getRecordingState() == AudioRecord.STATE_INITIALIZED)
 				 {
 				   audioRecord.startRecording();
 				   
@@ -530,6 +530,8 @@ public class VideoCameraActivity extends CameraBaseActivity {
 				   }
 				   
 				   audioRecord.stop();
+                   audioRecord.release();
+
 				   try {
 					   outputStreamAudio.flush();
 					outputStreamAudio.close();
@@ -537,7 +539,9 @@ public class VideoCameraActivity extends CameraBaseActivity {
 						// TODO Auto-generated catch block
 						e.printStackTrace();
 					}
-				 }
+				 } else {
+                     Log.d(TAG, "Failed to initialize AudioRecorder. Likely a device specific bug");
+                 }
 				 
 				 
 			 }


### PR DESCRIPTION
On some older Android devices, I've found that the AudioRecorder sometimes fails to initialize after recording multiple videos. On one of the devices, explicitly releasing the AudioRecorder fixes this issue.

However, on the other device this is not sufficient, and as such we disable audio recording instead of causing the app to crash due to 

> java.lang.IllegalStateException: startRecording() called on an uninitialized AudioRecord
